### PR TITLE
Fix get started compiler error & Add how to install scriggo command.

### DIFF
--- a/site/get-started-2.md
+++ b/site/get-started-2.md
@@ -148,10 +148,10 @@ func main() {
     globals := native.Declarations{
         "replace": builtin.Replace,
     }
-    opts := scriggo.Options{Globals: globals}
+    opts := scriggo.BuildOptions{Globals: globals}
 
     // Build the template.
-    template, err := scriggo.BuildTemplate(fsys, "index.html", opts)
+    template, err := scriggo.BuildTemplate(fsys, "index.html", &opts)
     if err != nil {
         log.Fatal(err)
     }
@@ -195,7 +195,7 @@ The following code defines a global function called "printHello" and passes it t
 globals := native.Declarations{
     "printHello": func (who string) string { return fmt.Sprintf("Hello, %s!", who) },
 }
-opts := scriggo.Options{Globals: globals}
+opts := scriggo.BuildOptions{Globals: globals}
 template, err := scriggo.BuildTemplate(fsys, "index.html", opts)
 ```
 

--- a/site/get-started.md
+++ b/site/get-started.md
@@ -112,6 +112,13 @@ of the importer can be coded manually or can be generated from a Scriggofile wit
 The `scriggo import` command allows to easily create an importer that imports the Go standard packages and other packages
 according to the instructions in a <a href="scriggofile">Scriggofile</a>.
 
+Get the scriggo command:
+
+```shell
+$ go install github.com/open2b/scriggo/cmd/scriggo@latest
+```
+
+
 Create a file called "Scriggofile" with the following contents and put it in the module directory:
 
 ```scriggofile


### PR DESCRIPTION
Hi! Thanks for the good tutorial for Scriggo!
(I'm not good at English, so I'm sorry if some parts are hard to understand. i used DeepL)

When I was learning with get started, there were a few things that bothered me, so I fixed them.

## Fixed point

site/get-started.md:
- Added `scriggo` command installation instructions since they were missing

site/get-started-2.md:
- Some parts were not working in the latest version(v0.51.1), so we fixed them to work


Let me know if there's anything in this PR that needs to be fixed or further explained! 